### PR TITLE
Feat : 도메인 및 DTO 작성

### DIFF
--- a/src/main/java/com/genai/tcoop/TcoopApplication.java
+++ b/src/main/java/com/genai/tcoop/TcoopApplication.java
@@ -2,8 +2,10 @@ package com.genai.tcoop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TcoopApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/genai/tcoop/model/constant/Gender.java
+++ b/src/main/java/com/genai/tcoop/model/constant/Gender.java
@@ -1,0 +1,5 @@
+package com.genai.tcoop.model.constant;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/genai/tcoop/model/constant/UserRole.java
+++ b/src/main/java/com/genai/tcoop/model/constant/UserRole.java
@@ -1,0 +1,5 @@
+package com.genai.tcoop.model.constant;
+
+public enum UserRole {
+    ADMIN, USER
+}

--- a/src/main/java/com/genai/tcoop/model/dto/PlanDTO.java
+++ b/src/main/java/com/genai/tcoop/model/dto/PlanDTO.java
@@ -1,0 +1,46 @@
+package com.genai.tcoop.model.dto;
+
+import com.genai.tcoop.model.entity.Plan;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlanDTO {
+
+    private Long id;
+    private PlannerDTO planner;
+    private String content;
+    private String address;
+    private String latitude;
+    private String longitude;
+    private String imageUrl;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Boolean isDeleted;
+
+    public static PlanDTO fromEntity(Plan entity) {
+        return PlanDTO.builder()
+                .id(entity.getId())
+                .planner(PlannerDTO.fromEntity(entity.getPlanner()))
+                .content(entity.getContent())
+                .address(entity.getAddress())
+                .latitude(entity.getLatitude())
+                .longitude(entity.getLongitude())
+                .imageUrl(entity.getImageUrl())
+                .startTime(entity.getStartTime())
+                .endTime(entity.getEndTime())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .isDeleted(entity.getIsDeleted())
+                .build();
+    }
+}

--- a/src/main/java/com/genai/tcoop/model/dto/PlannerDTO.java
+++ b/src/main/java/com/genai/tcoop/model/dto/PlannerDTO.java
@@ -1,0 +1,35 @@
+package com.genai.tcoop.model.dto;
+
+
+import com.genai.tcoop.model.entity.Planner;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlannerDTO {
+
+    private Long id;
+    private User user;
+    private String title;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Boolean isDeleted;
+
+    public static PlannerDTO fromEntity(Planner entity) {
+        return PlannerDTO.builder()
+                .id(entity.getId())
+                .user(User.fromEntity(entity.getUser()))
+                .title(entity.getTitle())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .isDeleted(entity.getIsDeleted())
+                .build();
+    }
+}

--- a/src/main/java/com/genai/tcoop/model/dto/User.java
+++ b/src/main/java/com/genai/tcoop/model/dto/User.java
@@ -1,0 +1,84 @@
+package com.genai.tcoop.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.genai.tcoop.model.constant.Gender;
+import com.genai.tcoop.model.constant.UserRole;
+import com.genai.tcoop.model.entity.UserAccount;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class User implements UserDetails {
+
+    private Long id;
+    private String username;
+    private String password;
+    private UserRole userRole;
+    private String name;
+    private String nickname;
+    private String birthday;
+    private Gender gender;
+    private String address;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Boolean isDeleted;
+
+    public static User fromEntity(UserAccount entity) {
+        return User.builder()
+                .id(entity.getId())
+                .username(entity.getUserAccountId())
+                .password(entity.getPassword())
+                .userRole(entity.getRole())
+                .name(entity.getName())
+                .nickname(entity.getNickname())
+                .birthday(entity.getBirthday())
+                .gender(entity.getGender())
+                .address(entity.getAddress())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .isDeleted(entity.getIsDeleted())
+                .build();
+    }
+
+    @Override
+    @JsonIgnore
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isAccountNonExpired() {
+        return !this.isDeleted;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isAccountNonLocked() {
+        return !this.isDeleted;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isCredentialsNonExpired() {
+        return !this.isDeleted;
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isEnabled() {
+        return !this.isDeleted;
+    }
+}

--- a/src/main/java/com/genai/tcoop/model/entity/BaseEntity.java
+++ b/src/main/java/com/genai/tcoop/model/entity/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.genai.tcoop.model.entity;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@JsonInclude(Include.NON_NULL)
+@Getter
+@ToString
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(columnDefinition = "bit default false NOT NULL COMMENT '이용가능여부'")
+    private Boolean isDeleted;
+}

--- a/src/main/java/com/genai/tcoop/model/entity/Plan.java
+++ b/src/main/java/com/genai/tcoop/model/entity/Plan.java
@@ -1,0 +1,47 @@
+package com.genai.tcoop.model.entity;
+
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "plan")
+@Entity
+public class Plan extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "planner_id")
+    private Planner planner;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "address")
+    private String address;
+
+    @Column(name = "latitude", nullable = false)
+    private String latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private String longitude;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "start_date")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startTime;
+
+    @Column(name = "end_date")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endTime;
+}

--- a/src/main/java/com/genai/tcoop/model/entity/Planner.java
+++ b/src/main/java/com/genai/tcoop/model/entity/Planner.java
@@ -1,0 +1,25 @@
+package com.genai.tcoop.model.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "planner")
+@Entity
+public class Planner extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "planner_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserAccount user;
+
+    @Column(name = "title")
+    private String title;
+}

--- a/src/main/java/com/genai/tcoop/model/entity/UserAccount.java
+++ b/src/main/java/com/genai/tcoop/model/entity/UserAccount.java
@@ -1,0 +1,46 @@
+package com.genai.tcoop.model.entity;
+
+import com.genai.tcoop.model.constant.Gender;
+import com.genai.tcoop.model.constant.UserRole;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "users")
+@Entity
+public class UserAccount extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "user_account_id", nullable = false)
+    private String userAccountId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "role")
+    @Enumerated(EnumType.STRING)
+    private UserRole role = UserRole.USER;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "nickname")
+    private String nickname;
+
+    @Column(name = "birthday")
+    private String birthday;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
+    private Gender gender;
+
+    @Column(name = "address")
+    private String address;
+}

--- a/src/main/java/com/genai/tcoop/response/Response.java
+++ b/src/main/java/com/genai/tcoop/response/Response.java
@@ -1,0 +1,28 @@
+package com.genai.tcoop.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Response<T> implements Serializable {
+
+    private String resultCode;
+    private T result;
+
+    public static Response<Void> error(String errorCode) {
+        return new Response<>(errorCode, null);
+    }
+
+    public static Response<Void> success() {
+        return new Response<Void>("SUCCESS", null);
+    }
+
+    public static <T> Response<T> success(T result) {
+        return new Response<>("SUCCESS", result);
+    }
+}


### PR DESCRIPTION
TCOOP 프로젝트에서 사용하기 위한 엔티티와 같은 도메인을 작성하였다.
추가적으로 엔티티를 그대로 사용하여 엔티티의 정보가 수정 또는 삭제된다면 DB에 저장된 정보가 변경될 수 있기 때문에
이를 위한 DTO를 작성하였으며, 클라이언트에게 일관된 형식의 응답을 전달하기 위한 기초적인 Response DTO를 구현하였다.

